### PR TITLE
Retrieve Tweet if transient  not false but filled with whitespace

### DIFF
--- a/widget-embed-latest-tweets.php
+++ b/widget-embed-latest-tweets.php
@@ -425,7 +425,7 @@ function welt_display_tweets( ){
 
 				$tweet_html_transient = get_transient('last_tweet_html_' . $tweet_id);
 
-				if( false === $tweet_html_transient ){
+                if( false === $tweet_html_transient || count($tweet_html_transient) <= 1){
 
 					$tweet_html_transient = welt_get_tweet_html( $tweet_id, $options );
 


### PR DESCRIPTION
It happens that a one character string is saved to transient. This introduces a chance for recovery.
